### PR TITLE
86c0gpy12 | `WinnerSet` event 

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -20,5 +20,12 @@ url = "https://api.apr.dev"
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
+[test]
+startup_wait = 60000
+
+[[test.genesis]]
+address = "2JWqYTXG5yHSU78hjKb39YFx82whbK74v6sMqMG3TVBQ"
+program = "target/deploy/degen_pools.so"
+
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.test.ts --parallel"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.test.ts"

--- a/programs/degen-pools/src/pools.rs
+++ b/programs/degen-pools/src/pools.rs
@@ -19,6 +19,12 @@ pub struct PoolCreated {
     pub description: String,
 }
 
+#[event]
+pub struct WinnerSet {
+    pub pool: Pubkey,
+    pub option: Pubkey,
+}
+
 pub fn create_pool(
     ctx: Context<CreatePool>,
     title: String,
@@ -63,6 +69,10 @@ pub fn set_winning_option(ctx: Context<UpdatePool>, winning_option: Pubkey) -> R
         return err!(CustomError::PoolStateIncompatible);
     }
     pool_account.winning_option = winning_option;
+    emit!(WinnerSet{
+        pool: pool_account.key(),
+        option: winning_option,
+    });
     Ok(())
 }
 


### PR DESCRIPTION
## What?
[Clickup Ticket 86c0gpy12](https://app.clickup.com/t/86c0gpy12)
This PR adds a `WinnerSet` event to the function `set_winning_option` on our `degen_pools` program.
We also added a few tweaks to _Anchor.toml_ to make testing easier

## Why?
Allows us to listen to winning option events via webhook

## How?
We created a new event `WinnerSet` and emit it. We test this using chai as well.

The testing setup was updated so that the local validator is automatically started, and then deployed with our program before starting the tests. This makes life so much easier.
The tests were non-parallelized so that events don't interfere with each other