### PR TITLE
86c0kq973 | Allow option creation only by pool creator 

### DIFF
--- a/programs/degen-pools/src/errors.rs
+++ b/programs/degen-pools/src/errors.rs
@@ -18,4 +18,6 @@ pub enum CustomError {
     ImageUrlTooLong,
     #[msg("The description is too long. Maximum length is 200 characters.")]
     DescriptionTooLong,
+    #[msg("Pool account does not match derived key")]
+    PoolAccountDoesNotMatch,
 }

--- a/programs/degen-pools/src/pool_options.rs
+++ b/programs/degen-pools/src/pool_options.rs
@@ -20,6 +20,16 @@ pub fn create_option(
     option_title: String,
     option_hash: [u8; 32],
 ) -> Result<()> {
+    // check that pool account is held by admin/signer
+    let title_hash = hash(ctx.accounts.pool_account.title.as_bytes().as_ref()).to_bytes();
+    let (derived_pool_account_key, _) = Pubkey::find_program_address(
+        &[&title_hash, ctx.accounts.admin.key().to_bytes().as_ref()],
+        ctx.program_id,
+    );
+    if derived_pool_account_key != ctx.accounts.pool_account.key() {
+        return err!(CustomError::PoolAccountDoesNotMatch);
+    }
+
     let mut derived_option_input = ctx.accounts.pool_account.key().to_string().to_owned();
     // Concatenate bytes using the concat method
     derived_option_input.push_str(&option_title);

--- a/programs/degen-pools/src/pools.rs
+++ b/programs/degen-pools/src/pools.rs
@@ -102,7 +102,7 @@ pub struct CreatePool<'info> {
         init,
         payer = admin,
         space = 8 + 1 + 32 + (4 + title.len()) + 8, // 8 bytes for discriminator, 1 byte for bool has_concluded, 32 bytes for Pubkey winning_option, 4 bytes for string + title length bytes, 8 for value
-        seeds = [&title_hash],
+        seeds = [&title_hash, admin.key().as_ref()],
         bump
     )]
     pub pool_account: Account<'info, Pool>,

--- a/tests/createOption.test.ts
+++ b/tests/createOption.test.ts
@@ -98,4 +98,37 @@ describe("Option Creation", () => {
       expect(e.message).to.include("An address constraint was violated");
     }
   });
+
+  it("allows only the pool creator to create options", async () => {
+    const kp1 = await generateKeypair();
+    const kp2 = await generateKeypair();
+    const randomSuffix = Math.random().toString(36).substring(7);
+    const { poolAccountKey } = await createPool(
+      `pool1_${randomSuffix}`,
+      kp1,
+      "",
+      "",
+    );
+    const optionTitle = `option1_${randomSuffix}`;
+
+    // failure case
+    try {
+      await createOption(optionTitle, kp2, poolAccountKey);
+      throw new Error("This try block should have errored above");
+    } catch (e) {
+      expect(e.message).to.include("Pool account does not match derived key");
+    }
+
+    // success case
+    const { optionAccountKey } = await createOption(
+      optionTitle,
+      kp1,
+      poolAccountKey,
+    );
+    const expectedOptionAccountKey = await deriveOptionAccountKey(
+      optionTitle,
+      poolAccountKey,
+    );
+    expect(optionAccountKey.equals(expectedOptionAccountKey)).to.be.true;
+  });
 });

--- a/tests/utils/pools.ts
+++ b/tests/utils/pools.ts
@@ -2,9 +2,12 @@ import { program } from "./constants";
 import { getBytesFromHashedStr, getTitleHash } from "./cryptography";
 import * as anchor from "@coral-xyz/anchor";
 
-export const derivePoolAccountKey = async (title: string) => {
+export const derivePoolAccountKey = async (
+  title: string,
+  creator: anchor.web3.Keypair,
+) => {
   const [pda] = anchor.web3.PublicKey.findProgramAddressSync(
-    [getBytesFromHashedStr(title)],
+    [getBytesFromHashedStr(title), creator.publicKey.toBytes()],
     program.programId,
   );
   return pda;
@@ -24,11 +27,11 @@ export const createPool = async (
     throw new Error("Description exceeds the maximum length of 200 characters");
   }
 
-  const poolAccountKey = await derivePoolAccountKey(title);
+  const poolAccountKey = await derivePoolAccountKey(title, keypair);
 
   await program.methods
     .createPool(title, getTitleHash(title), imageUrl, description)
-    .accounts({
+    .accountsStrict({
       poolAccount: poolAccountKey,
       admin: keypair.publicKey,
       systemProgram: anchor.web3.SystemProgram.programId,
@@ -51,7 +54,7 @@ export const pausePool = async (
 ) =>
   program.methods
     .setIsPaused(isPaused)
-    .accounts({
+    .accountsStrict({
       poolAccount: poolAccountKey,
       admin: adminWallet.publicKey,
     })
@@ -65,7 +68,7 @@ export const setWinningOption = async (
 ) =>
   program.methods
     .setWinningOption(optionAccountKey)
-    .accounts({
+    .accountsStrict({
       poolAccount: poolAccountKey,
       admin: adminWallet.publicKey,
     })


### PR DESCRIPTION
## What?
[Clickup Ticket 86c0kq973](https://app.clickup.com/t/86c0kq973)
This PR restricts creating of options to only the creator of the associated pool

## Why?
We don't want just anyone to create options for any pool

## How?
The pool account key is now derived from title and the creator's pubkey. When the option is being created, we derive the pool account key for the given pool account title and the address of the sender. If the derived pool account key matches the one being sent in, then the sender of create-option txn, is indeed the creator of that pool account.

We test for this as well