### PR TITLE
Fix try-catch and event listener issues in tests

### DIFF
--- a/tests/claimWin.test.ts
+++ b/tests/claimWin.test.ts
@@ -45,9 +45,9 @@ describe("Wins claiming and WinClaimed Event", () => {
     await claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user);
 
     // account deleted after a successful win claim
-    await expect(async () => {
-      await claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user);
-    }).rejects.toThrow("EntryAlreadyClaimed");
+    await expect(
+      claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user),
+    ).rejects.toThrow("EntryAlreadyClaimed");
   });
 
   it("should not let a user claim using someone else's entry account", async () => {
@@ -82,9 +82,9 @@ describe("Wins claiming and WinClaimed Event", () => {
     await pausePool(true, poolAccountKey, adminWallet);
     await setWinningOption(poolAccountKey, optionAccountKey, adminWallet);
 
-    await expect(async () => {
-      await claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user1);
-    }).rejects.toThrow("EntryNotDerivedFromOptionOrSigner");
+    await expect(
+      claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user1),
+    ).rejects.toThrow("EntryNotDerivedFromOptionOrSigner");
 
     // ensure account is not deleted after failed claim win (no exception is thrown)
     await program.account.entry.fetch(entryAccountKey);
@@ -138,23 +138,13 @@ describe("Wins claiming and WinClaimed Event", () => {
     await pausePool(true, poolAccountKey, adminWallet);
     await setWinningOption(poolAccountKey, optionAccountKey, adminWallet);
 
-    await expect(async () => {
-      await claimWin(
-        poolAccountKey,
-        wrongOptionAccountKey,
-        entryAccountKey,
-        user,
-      );
-    }).rejects.toThrow("LosingOption");
+    await expect(
+      claimWin(poolAccountKey, wrongOptionAccountKey, entryAccountKey, user),
+    ).rejects.toThrow("LosingOption");
 
-    await expect(async () => {
-      await claimWin(
-        poolAccountKey,
-        optionAccountKey,
-        wrongOptionEntryKey,
-        user,
-      );
-    }).rejects.toThrow("EntryNotDerivedFromOptionOrSigner");
+    await expect(
+      claimWin(poolAccountKey, optionAccountKey, wrongOptionEntryKey, user),
+    ).rejects.toThrow("EntryNotDerivedFromOptionOrSigner");
   });
 
   it("should claim the user's share of the win", async () => {
@@ -223,9 +213,7 @@ describe("Wins claiming and WinClaimed Event", () => {
     expect(winClaimedEvent.pool.toString()).toEqual(poolAccountKey.toString());
 
     // claiming a win closes the entry account for the user to refund the lamports
-    await expect(async () => {
-      await program.account.entry.fetch(entryAccountKey);
-    }).rejects.toThrow(
+    await expect(program.account.entry.fetch(entryAccountKey)).rejects.toThrow(
       `Account does not exist or has no data ${entryAccountKey}`,
     );
   });

--- a/tests/claimWin.test.ts
+++ b/tests/claimWin.test.ts
@@ -38,12 +38,10 @@ describe("Wins claiming and WinClaimed Event", () => {
 
     await claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user);
 
-    try {
+    // account deleted after a successful win claim
+    await expect(async () => {
       await claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user);
-    } catch (e) {
-      // account deleted after a successful win claim
-      expect(e.message).toContain("EntryAlreadyClaimed");
-    }
+    }).rejects.toThrow("EntryAlreadyClaimed");
   });
 
   it("should not let a user claim using someone else's entry account", async () => {
@@ -78,11 +76,9 @@ describe("Wins claiming and WinClaimed Event", () => {
     await pausePool(true, poolAccountKey, adminWallet);
     await setWinningOption(poolAccountKey, optionAccountKey, adminWallet);
 
-    try {
+    await expect(async () => {
       await claimWin(poolAccountKey, optionAccountKey, entryAccountKey, user1);
-    } catch (e) {
-      expect(e.message).toContain("EntryNotDerivedFromOptionOrSigner");
-    }
+    }).rejects.toThrow("EntryNotDerivedFromOptionOrSigner");
 
     // ensure account is not deleted after failed claim win (no exception is thrown)
     await program.account.entry.fetch(entryAccountKey);
@@ -136,27 +132,23 @@ describe("Wins claiming and WinClaimed Event", () => {
     await pausePool(true, poolAccountKey, adminWallet);
     await setWinningOption(poolAccountKey, optionAccountKey, adminWallet);
 
-    try {
+    await expect(async () => {
       await claimWin(
         poolAccountKey,
         wrongOptionAccountKey,
         entryAccountKey,
         user,
       );
-    } catch (e) {
-      expect(e.message).toContain("LosingOption");
-    }
+    }).rejects.toThrow("LosingOption");
 
-    try {
+    await expect(async () => {
       await claimWin(
         poolAccountKey,
         optionAccountKey,
         wrongOptionEntryKey,
         user,
       );
-    } catch (e) {
-      expect(e.message).toContain("EntryNotDerivedFromOptionOrSigner");
-    }
+    }).rejects.toThrow("EntryNotDerivedFromOptionOrSigner");
   });
 
   it("should claim the user's share of the win", async () => {
@@ -244,12 +236,10 @@ describe("Wins claiming and WinClaimed Event", () => {
     await claimWin(poolAccountKey, optionAccountKey, entry1AccountKey, user1);
 
     // claiming a win closes the entry account for the user to refund the lamports
-    try {
+    await expect(async () => {
       await program.account.entry.fetch(entryAccountKey);
-    } catch (e) {
-      expect(e.message).toContain(
-        `Account does not exist or has no data ${entryAccountKey}`,
-      );
-    }
+    }).rejects.toThrow(
+      `Account does not exist or has no data ${entryAccountKey}`,
+    );
   });
 });

--- a/tests/createOption.test.ts
+++ b/tests/createOption.test.ts
@@ -53,8 +53,8 @@ describe("Option Creation", () => {
       poolAccountKey,
     );
 
-    await expect(async () => {
-      await program.methods
+    await expect(
+      program.methods
         .createOption(
           "randomText",
           getOptionTitleHash(poolAccountKey, optionTwo) as unknown as number[],
@@ -66,8 +66,8 @@ describe("Option Creation", () => {
           systemProgram: anchor.web3.SystemProgram.programId,
         })
         .signers([authorityKeypair])
-        .rpc();
-    }).rejects.toThrow("PoolOptionDoesNotMatchHash");
+        .rpc(),
+    ).rejects.toThrow("PoolOptionDoesNotMatchHash");
   });
 
   it("allows only the pool creator to create options", async () => {
@@ -83,9 +83,9 @@ describe("Option Creation", () => {
     const optionTitle = `option1_${randomSuffix}`;
 
     // failure case
-    await expect(async () => {
-      await createOption(optionTitle, kp2, poolAccountKey);
-    }).rejects.toThrow("PoolAccountDoesNotMatch");
+    await expect(
+      createOption(optionTitle, kp2, poolAccountKey),
+    ).rejects.toThrow("PoolAccountDoesNotMatch");
 
     // success case
     const { optionAccountKey } = await createOption(

--- a/tests/createPool.test.ts
+++ b/tests/createPool.test.ts
@@ -57,11 +57,9 @@ describe("Pool Creation", () => {
 
     await createPool(title, authorityKeypair, imageUrl, description);
 
-    try {
+    await expect(async () => {
       await createPool(title, authorityKeypair, imageUrl, description);
-    } catch (e) {
-      expect(e.message).toContain("custom program error: 0x0");
-    }
+    }).rejects.toThrow(/account Address .*? already in use/);
   });
 
   it("should fail if a random wallet is used to create a pool", async () => {
@@ -71,11 +69,9 @@ describe("Pool Creation", () => {
     const description =
       "This is a pool to guess if $MOG will reach a $2 B market cap.";
 
-    try {
+    await expect(async () => {
       await createPool(title, randomWallet, imageUrl, description);
-    } catch (e) {
-      expect(e.message).toContain("An address constraint was violated");
-    }
+    }).rejects.toThrow("An address constraint was violated");
   });
 
   it("should fail if title does not match the title hash", async () => {
@@ -85,7 +81,7 @@ describe("Pool Creation", () => {
     const description = "This is a pool to guess the outcome of Tate vs Ansem.";
     const poolAccountKey = await derivePoolAccountKey(title, authorityKeypair);
 
-    try {
+    await expect(async () => {
       await program.methods
         .createPool(title, getTitleHash("randomString"), imageUrl, description)
         .accounts([
@@ -95,8 +91,6 @@ describe("Pool Creation", () => {
         ])
         .signers([authorityKeypair])
         .rpc();
-    } catch (e) {
-      expect(e.message).toContain("TitleDoesNotMatchHash");
-    }
+    }).rejects.toThrow("TitleDoesNotMatchHash");
   });
 });

--- a/tests/createPool.test.ts
+++ b/tests/createPool.test.ts
@@ -53,9 +53,9 @@ describe("Pool Creation", () => {
 
     await createPool(title, authorityKeypair, imageUrl, description);
 
-    await expect(async () => {
-      await createPool(title, authorityKeypair, imageUrl, description);
-    }).rejects.toThrow(/account Address .*? already in use/);
+    await expect(
+      createPool(title, authorityKeypair, imageUrl, description),
+    ).rejects.toThrow(/account Address .*? already in use/);
   });
 
   it("should fail if a random wallet is used to create a pool", async () => {
@@ -77,8 +77,8 @@ describe("Pool Creation", () => {
     const description = "This is a pool to guess the outcome of Tate vs Ansem.";
     const poolAccountKey = await derivePoolAccountKey(title, authorityKeypair);
 
-    await expect(async () => {
-      await program.methods
+    await expect(
+      program.methods
         .createPool(title, getTitleHash("randomString"), imageUrl, description)
         .accounts([
           poolAccountKey,
@@ -86,7 +86,7 @@ describe("Pool Creation", () => {
           anchor.web3.SystemProgram.programId,
         ])
         .signers([authorityKeypair])
-        .rpc();
-    }).rejects.toThrow("TitleDoesNotMatchHash");
+        .rpc(),
+    ).rejects.toThrow("TitleDoesNotMatchHash");
   });
 });

--- a/tests/enterPool.test.ts
+++ b/tests/enterPool.test.ts
@@ -70,16 +70,14 @@ describe("Pool Entry", () => {
       poolAccountKey,
     );
     await pausePool(true, poolAccountKey, adminWallet);
-    try {
+    await expect(async () => {
       await enterPool(
         poolAccountKey,
         optionAccountKey,
         userWallet,
         new BN(100_000),
       );
-    } catch (e) {
-      expect(e.message).toContain("PoolStateIncompatible");
-    }
+    }).rejects.toThrow("PoolStateIncompatible");
   });
 
   it("should not create an Entry if a user does not have enough balance", async () => {
@@ -104,23 +102,13 @@ describe("Pool Entry", () => {
       adminWallet,
       poolAccountKey,
     );
-    try {
+    await expect(async () => {
       await enterPool(
         poolAccountKey,
         optionAccountKey,
         userWallet,
         new BN(userBalance + 1),
       );
-    } catch (e) {
-      const entryAccountKey = await deriveEntryAccountKey(
-        optionAccountKey,
-        userWallet,
-      );
-      try {
-        await program.account.entry.fetch(entryAccountKey);
-      } catch (e) {
-        expect(e.message).toContain("Account does not exist or has no data");
-      }
-    }
+    }).rejects.toThrow("Transfer: insufficient lamports");
   });
 });

--- a/tests/enterPool.test.ts
+++ b/tests/enterPool.test.ts
@@ -67,14 +67,9 @@ describe("Pool Entry", () => {
       poolAccountKey,
     );
     await pausePool(true, poolAccountKey, adminWallet);
-    await expect(async () => {
-      await enterPool(
-        poolAccountKey,
-        optionAccountKey,
-        userWallet,
-        new BN(100_000),
-      );
-    }).rejects.toThrow("PoolStateIncompatible");
+    await expect(
+      enterPool(poolAccountKey, optionAccountKey, userWallet, new BN(100_000)),
+    ).rejects.toThrow("PoolStateIncompatible");
   });
 
   it("should not create an Entry if a user does not have enough balance", async () => {
@@ -99,13 +94,13 @@ describe("Pool Entry", () => {
       adminWallet,
       poolAccountKey,
     );
-    await expect(async () => {
-      await enterPool(
+    await expect(
+      enterPool(
         poolAccountKey,
         optionAccountKey,
         userWallet,
         new BN(userBalance + 1),
-      );
-    }).rejects.toThrow("Transfer: insufficient lamports");
+      ),
+    ).rejects.toThrow("Transfer: insufficient lamports");
   });
 });

--- a/tests/poolPaused.test.ts
+++ b/tests/poolPaused.test.ts
@@ -1,12 +1,14 @@
 import { getLocalAccount } from "./utils/keypairs";
 import { pausePool, createPool } from "./utils/pools";
+import { EventListenerService } from "./utils/events";
 import { program } from "./utils/constants";
-import { IdlEvents } from "@coral-xyz/anchor";
 
 describe("Pool Paused", () => {
   let adminWallet;
   let poolAccountKey;
   const randomChar = Math.random().toString(36).charAt(2);
+  const listenerService = new EventListenerService();
+
   beforeAll(async () => {
     adminWallet = await getLocalAccount();
     const title = `Will DOGE hit $1.5 in 2025 (${randomChar})?`;
@@ -24,42 +26,22 @@ describe("Pool Paused", () => {
     poolAccountKey = createdPoolAccountKey;
   });
 
+  afterAll(async () => {
+    await listenerService.reset();
+  });
+
   it("should emit a poolStatusUpdated event when the pool is paused", async () => {
-    let listener;
-
-    const poolPausedListenerPromise = new Promise<
-      IdlEvents<typeof program.idl>["poolStatusUpdated"]
-    >((resolve) => {
-      listener = program.addEventListener("poolStatusUpdated", (event) => {
-        resolve(event);
-      });
-    });
-
+    const listener = listenerService.listen("poolStatusUpdated");
     await pausePool(true, poolAccountKey, adminWallet);
-
-    const event = await poolPausedListenerPromise;
-    await program.removeEventListener(listener);
-
+    const event = await listener;
     expect(event.pool.toString()).toEqual(poolAccountKey.toString());
     expect(event.isPaused).toEqual(true);
   });
 
   it("should emit a poolStatusUpdated event when the pool is unpaused", async () => {
-    let listener;
-
-    const unpausePoolListenerPromise = new Promise<
-      IdlEvents<typeof program.idl>["poolStatusUpdated"]
-    >((resolve) => {
-      listener = program.addEventListener("poolStatusUpdated", (event) => {
-        resolve(event);
-      });
-    });
-
+    const listener = listenerService.listen("poolStatusUpdated");
     await pausePool(false, poolAccountKey, adminWallet);
-
-    const unpausedEvent = await unpausePoolListenerPromise;
-    await program.removeEventListener(listener);
-
+    const unpausedEvent = await listener;
     expect(unpausedEvent.pool.toString()).toEqual(poolAccountKey.toString());
     expect(unpausedEvent.isPaused).toEqual(false);
   });

--- a/tests/utils/constants.ts
+++ b/tests/utils/constants.ts
@@ -5,3 +5,5 @@ export const provider = anchor.AnchorProvider.env();
 anchor.setProvider(provider);
 export const program = anchor.workspace
   .DegenPools as anchor.Program<DegenPools>;
+
+export type DegenPoolsEvents = anchor.IdlEvents<DegenPools>;

--- a/tests/utils/events.ts
+++ b/tests/utils/events.ts
@@ -1,0 +1,52 @@
+import { DegenPoolsEvents, program } from "./constants";
+
+/**
+ *
+ * This class abstracts away the logic of managing event listener handlers for you.
+ * The benefit is it avoids the need to manually remove listeners. If you don't remove
+ * listeners, they will prevent the test process from exiting.
+ *
+ * Another benefit is you don't need
+ * @usage
+ * ```ts
+ * let listenerService: EventListenerService;
+ *
+ * beforeAll(() => {
+ *   listenerService = new EventListenerService();
+ * });
+ *
+ * it("should have correct event", async () => {
+ *   listener = listenerService.listen("myEventName");
+ *   await triggerMyEvent();
+ *   const event = await listener;
+ *   expect(event.value).toEqual(expectedValue);
+ * });
+ *
+ * afterAll(() => {
+ *   await listenerService.reset();
+ * });
+ * ```
+ */
+export class EventListenerService {
+  private activeListeners: number[] = [];
+
+  listen<T extends keyof DegenPoolsEvents>(eventName: T) {
+    return new Promise<DegenPoolsEvents[T]>((res) => {
+      const listener = program.addEventListener(
+        eventName,
+        async (e: DegenPoolsEvents[T]) => {
+          res(e);
+        },
+      );
+      this.activeListeners.push(listener);
+    });
+  }
+
+  async reset() {
+    await Promise.all(
+      this.activeListeners.map(async (listener) => {
+        await program.removeEventListener(listener);
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## What?
This PR does the following:
1. Use `expect().rejects.toThrow()` instead of `try-catch`
2. Implements the `EventListenerService` for easy management of blockchain event listeners

## Why?
Our test cases had some issues:
1. **Try-catch:** Test blocks that were expected to fail were using try-catch. But this is problematic, since it doesn't guarantee that the commands in the try catch will throw an error
2. **Event listeners:** Our event listener code was verbose and often repeated. Also, in many places the event listener was left un-closed, resulting in open handles that prevent the test process from exiting